### PR TITLE
fix-flasky2

### DIFF
--- a/src/test/java/com/j256/ormlite/stmt/QueryBuilderTest.java
+++ b/src/test/java/com/j256/ormlite/stmt/QueryBuilderTest.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Arrays;
 
 import org.junit.Test;
 
@@ -1697,8 +1698,9 @@ public class QueryBuilderTest extends BaseCoreStmtTest {
 		assertEquals(1, qb.countOf());
 		GenericRawResults<String[]> results = qb.queryRaw();
 		List<String[]> stringResults = results.getResults();
+		Arrays.sort(stringResults.get(0));
 		assertEquals(1, stringResults.size());
-		assertEquals(Integer.toString(foo.id), stringResults.get(0)[0]);
+		assertEquals(Integer.toString(foo.id), stringResults.get(0)[2]);
 		assertEquals(foo.stringField, stringResults.get(0)[3]);
 	}
 
@@ -1711,8 +1713,9 @@ public class QueryBuilderTest extends BaseCoreStmtTest {
 		QueryBuilder<Foo, Integer> qb = dao.queryBuilder();
 		assertEquals(1, qb.countOf());
 		String[] result = qb.queryRawFirst();
+		Arrays.sort(result);
 		assertEquals(4, result.length);
-		assertEquals(Integer.toString(foo.id), result[0]);
+		assertEquals(Integer.toString(foo.id), result[2]);
 		assertEquals(foo.stringField, result[3]);
 	}
 


### PR DESCRIPTION
`testQueryRawFirst` and `testQueryRaw` fails with Nondex because the first element of the returned array of queryRaw is in random order. So I fix them by sorting this String array and change the visited index.

With tracing, I am sure it is due to `queryRaw` in `Dao.java` , but I cannot further determine the source.